### PR TITLE
Simpler PR for Shadows and terrain blending.

### DIFF
--- a/BuildTileset.sh
+++ b/BuildTileset.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+
+# This can be the "build script" for the tileset.
+# Alternatively, you could rewrite it entirely in Python.
+# Based on 5Hex.
+
+# ===LICENSE===
+# By https://github.com/will-ca/, https://github.com/Intralexical.
+# http://creativecommons.org/publicdomain/zero/1.0/
+# To the extent possible under law, the person who associated CC0 with this work has waived all copyright and related or neighboring rights to this work.
+
+set -eu
+
+
+DIR="$(dirname "$(readlink -f "$0")")"
+
+target="$DIR/Images/TileSets/5Hex"
+echo && echo "Deleting previous build: $target"
+sleep 1
+rm -rfv "$target"
+
+source="$DIR/src/5Hex"
+echo && echo "Copying source to target: $source → $target"
+sleep 1
+cp -r "$source" "$target"
+
+
+transformer="$DIR/TileTransformer.py"
+echo && echo "Using TileTransformer.py at $transformer."
+sleep 2
+
+
+cd "$target"
+
+
+SCALE=1.5
+FUZZEDSCALE=1.5
+#FUZZEDSHIFT=-0.125
+#RIVERSHIFT=0.125
+
+FUZZ_TILES=("Tiles/Ocean.png" "Tiles/Coast.png" "Tiles/Grassland.png" "Tiles/Grassland+Marsh.png" "Tiles/Great Barrier Reef.png" "Tiles/Plains.png" "Tiles/Tundra.png" "Tiles/Desert.png" "Tiles/Lakes.png" "Tiles/Snow.png" "Tiles/Fallout.png" "Tiles/Flood plains.png")
+
+#BASE_TILES=("${FUZZ_TILES[@]}" "Tiles/Mountain.png")
+
+BACKGROUND_GRASSLAND_TILES=("Tiles/El Dorado.png" "Tiles/Fountain of Youth.png" "Tiles/Mount Kilimanjaro.png" "Tiles/Rock of Gibraltar.png" "Tiles/Sri Pada.png" "Tiles/Mountain.png")
+BACKGROUND_DESERT_TILES=("Tiles/Mount Sinai.png")
+BACKGROUND_PLAINS_TILES=("Tiles/Barringer Crater.png" "Tiles/Grand Mesa.png" "Tiles/King Solomon's Mines.png" "Tiles/Lakes+Lake Victoria.png" "Tiles/Mount Kailash.png" "Tiles/Old Faithful.png" "Tiles/Uluru.png")
+GRASSLAND="Tiles/Grassland.png"; DESERT="Tiles/Desert.png"; PLAINS="Tiles/Plains.png"
+
+RIVER_TILES=("Tiles/River-Bottom.png" "Tiles/River-BottomLeft.png" "Tiles/River-BottomRight.png")
+
+SHEARSHADOW_TILES=("Tiles/Academy.png" "Tiles/AcademySnowy.png" "Tiles/Aluminum+Mine.png" "Tiles/Ancient ruins.png" "Tiles/Ancient ruins2.png" "Tiles/AncientRuinsDesert.png" "Tiles/AncientRuinsForests.png" "Tiles/AncientRuinsSnowTundra.png" "Tiles/Antiquity Site.png" "Tiles/Cerro de Potosi.png" "Tiles/Chateau.png" "Tiles/Citadel.png" "Tiles/Coal+Mine.png" "Tiles/Copper+Mine.png" "Tiles/Feitoria.png" "Tiles/Iron+Mine.png" "Tiles/Krakatoa.png" "Tiles/Mountain.png" "Tiles/Mount Fuji.png" "Tiles/Silver+Mine.png" "Tiles/Sri Pada.png" "Tiles/Uluru.png" "Tiles/Uranium+Mine.png")
+
+DROPSHADOW_TILES=("Tiles/Aluminum.png" "Tiles/Archaeological Dig.png" "Tiles/Bananas.png" "Tiles/Bananas+Plantation.png" "Tiles/Barbarian encampment.png" "Tiles/Bison.png" "Tiles/Bison+Camp.png" "Tiles/Cattle.png" "Tiles/Cattle+Pasture.png" "Tiles/Citrus.png" "Tiles/Citrus+Plantation.png" "Tiles/City center.png" "Tiles/City center-Ancient era.png" "Tiles/City center-Atomic era.png" "Tiles/City center-Classical era.png" "Tiles/City center-Future era.png" "Tiles/City center-Industrial era.png" "Tiles/City center-Information era.png" "Tiles/City center-Medieval era.png" "Tiles/City center-Modern era.png" "Tiles/City center-Renaissance era.png" "Tiles/City ruins.png" "Tiles/Coal.png" "Tiles/Cocoa.png" "Tiles/Cocoa+Plantation.png" "Tiles/Colossal Head.png" "Tiles/Copper.png" "Tiles/Cotton.png" "Tiles/Cotton+Plantation.png" "Tiles/Crab.png" "Tiles/Crab+Fishing Boats.png" "Tiles/Customs house.png" "Tiles/Deer.png" "Tiles/Deer+Camp.png" "Tiles/Dyes.png" "Tiles/Dyes+Plantation.png" "Tiles/Farm.png" "Tiles/Fish+Fishing Boats.png" "Tiles/Fishing Boats.png" "Tiles/Flood plains.png" "Tiles/Forest.png" "Tiles/Forest+Citrus.png" "Tiles/Forest+Deer.png" "Tiles/Forest+Deer+Camp.png" "Tiles/Forest+Dyes.png" "Tiles/Forest+Furs.png" "Tiles/Forest+Furs+Camp.png" "Tiles/Forest+Lumber mill.png" "Tiles/Forest+Sacred Grove.png" "Tiles/Forest+Silk.png" "Tiles/Forest+Spices.png" "Tiles/Forest +Trading post.png" "Tiles/Forest+Truffles.png" "Tiles/Forest+Truffles+Camp.png" "Tiles/Fort.png" "Tiles/Fountain of Youth.png" "Tiles/Furs.png" "Tiles/Furs+Camp.png" "Tiles/Gems.png" "Tiles/Gems+Mine.png" "Tiles/Gold Ore.png" "Tiles/Gold Ore+Mine.png" "Tiles/HF.png" "Tiles/HF+Citrus.png" "Tiles/HF+Deer.png" "Tiles/HF+Deer+Camp.png" "Tiles/HF+Dyes.png" "Tiles/HF+Furs.png" "Tiles/HF+Furs+Camp.png" "Tiles/HF+Lumber mill.png" "Tiles/HF+Sacred Grove.png" "Tiles/HF+Silk.png" "Tiles/HF+Spices.png" "Tiles/HF+Trading post.png" "Tiles/HF+Truffles.png" "Tiles/HF+Truffles+Camp.png" "Tiles/Holy Place.png" "Tiles/Holy site.png" "Tiles/Horses.png" "Tiles/Horses+Pasture.png" "Tiles/Ice.png" "Tiles/Incense.png" "Tiles/Incense+Plantation.png" "Tiles/Iron.png" "Tiles/Ivory.png" "Tiles/Ivory+Camp.png" "Tiles/Jungle.png" "Tiles/Jungle+Ancient ruins.png" "Tiles/Jungle+Bananas.png" "Tiles/Jungle+Brazilwood camp.png" "Tiles/Jungle+Citrus.png" "Tiles/Jungle+Cocoa.png" "Tiles/Jungle+Dyes.png" "Tiles/Jungle+Sacred Grove.png" "Tiles/Jungle+Spices.png" "Tiles/Jungle+Trading post.png" "Tiles/Jungle+Truffles.png" "Tiles/Jungle+Truffles+Camp.png" "Tiles/Kasbah.png" "Tiles/Kurgan.png" "Tiles/Landmark.png" "Tiles/Land Trade Route (Food).png" "Tiles/Land Trade Route (Gold).png" "Tiles/Land Trade Route (Production).png" "Tiles/Manufactory.png" "Tiles/Marble.png" "Tiles/Marble+Quarry.png" "Tiles/Mine.png" "Tiles/Moai.png" "Tiles/Oasis.png" "Tiles/Offshore platform.png" "Tiles/Oil well.png" "Tiles/Pasture.png" "Tiles/Pearls.png" "Tiles/Pearls+Fishing Boats.png" "Tiles/Polder.png" "Tiles/Sacred Place.png" "Tiles/Salt.png" "Tiles/Salt+Mine.png" "Tiles/Seaside Stall.png" "Tiles/Sea Trade Route (Food).png" "Tiles/Sea Trade Route (Gold).png" "Tiles/Sea Trade Route (Production).png" "Tiles/Sheep.png" "Tiles/Sheep+Pasture.png" "Tiles/Silk.png" "Tiles/Silk+Plantation.png" "Tiles/Silver.png" "Tiles/Spices.png" "Tiles/Spices+Plantation.png" "Tiles/Stone.png" "Tiles/Stone+Quarry.png" "Tiles/Sugar.png" "Tiles/Sugar+Plantation.png" "Tiles/Terrace farm.png" "Tiles/TF.png" "Tiles/TF+Citrus.png" "Tiles/TF+Deer.png" "Tiles/TF+Deer+Camp.png" "Tiles/TF+Dyes.png" "Tiles/TF+Furs.png" "Tiles/TF+Furs+Camp.png" "Tiles/TF+Lumber mill.png" "Tiles/TF+Sacred Grove.png" "Tiles/TF+Silk.png" "Tiles/TF+Spices.png" "Tiles/TF+Trading post.png" "Tiles/TF+Truffles.png" "Tiles/TF+Truffles+Camp.png" "Tiles/Trading post.png" "Tiles/Truffles.png" "Tiles/Truffles+Camp.png" "Tiles/Uranium.png" "Tiles/Whales.png" "Tiles/Whales+Fishing Boats.png" "Tiles/Wheat.png" "Tiles/Wheat+Farm.png" "Tiles/Wine.png" "Tiles/Wine+Plantation.png")
+
+
+"$transformer" "expand(scale=$SCALE, topmargin=1.0)" Tiles/*.png
+
+"$transformer" "shearShadow(scale=$SCALE, base=0.5, opacity=0.7, blur=0.05, length=1.15, shear=0.6)" "${SHEARSHADOW_TILES[@]}"
+"$transformer" "dropShadow(scale=$SCALE, opacity=0.5, blur=0.01, x=0.05, y=0.05)" "${DROPSHADOW_TILES[@]}"
+
+"$transformer" "tesselate($SCALE)" "${FUZZ_TILES[@]}"
+"$transformer" "fuzzPolygonalFeather($SCALE, $FUZZEDSCALE)" "${FUZZ_TILES[@]}"
+
+"$transformer" "addBackground('$GRASSLAND')" "${BACKGROUND_GRASSLAND_TILES[@]}"
+"$transformer" "addBackground('$DESERT')" "${BACKGROUND_DESERT_TILES[@]}"
+"$transformer" "addBackground('$PLAINS')" "${BACKGROUND_PLAINS_TILES[@]}"
+
+#"$transformer" "shift($SCALE, y=$FUZZEDSHIFT)" "${BASE_TILES[@]}"
+#"$transformer" "shift($SCALE, y=$RIVERSHIFT)" "${RIVER_TILES[@]}"
+
+
+"$transformer" "expand(scale=$SCALE, topmargin=1.0)" Units/*.png
+"$transformer" "shearShadow(scale=$SCALE, base=0.1, opacity=0.5, blur=0.015)" Units/*.png
+
+
+"$transformer" "expand(scale=$SCALE, topmargin=0)" Hexagon.png
+"$transformer" "expand(scale=$SCALE, topmargin=0)" Borders/*.png
+"$transformer" "expand(scale=$SCALE, topmargin=0)" Crosshair.png CrosshatchHexagon.png Highlight.png
+
+echo && echo "Tileset build complete."
+

--- a/TileTransformer.py
+++ b/TileTransformer.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+
+"""
+Example Python utility for automatically converting Unciv tilesets to make use of https://github.com/yairm210/Unciv/pull/5874.
+
+See BuildTileset.sh for example use.
+
+License:
+	By https://github.com/will-ca/, https://github.com/Intralexical.
+
+	This Source Code Form is subject to the terms of the Mozilla Public
+	License, v. 2.0. If a copy of the MPL was not distributed with this
+	file, You can obtain one at https://mozilla.org/MPL/2.0/.
+"""
+
+# TIP: Most of these functions can accept either a filepath or an image object as their primary operand. This makes them easily chainable/nestable.
+# TIP: Most of these functions return `PIL.Image.Image` instances. Call their `.show()` method to preview them.
+# E.G.: maskedHexImage(tesselatedHexImage(expandedHexImage("Hexagon.png", 1.5), 1.5), 1.5, hexMaskPolygonalBalanced(1.5)).show()
+
+import PIL.Image, PIL.ImageEnhance, math
+
+
+HEX_HEIGHT = math.sqrt(0.75) # Hexagon height— But I've also seen 7:9 thrown around for Unciv?
+
+def asImage(image):
+	"""Return a PIL image from a given PIL image or filepath."""
+	if not isinstance(image, PIL.Image.Image):
+		image = PIL.Image.open(image)
+	return image.convert('RGBA')
+
+def asSize(size):
+	"""Return an size tuple from a given size tuple or image."""
+	return size.size if isinstance(size, PIL.Image.Image) else size
+
+def blankFrom(size):
+	"""Make a new transparent image from a given image or size tuple."""
+	return PIL.Image.new('RGBA', asSize(size), (0,0,0,0))
+
+def hexSize(image, expandedfac):
+	"""Calculate the bounding rectangle dimensions of the hex area on an expanded hex tile."""
+	return (image.size[0] / expandedfac, image.size[0] / expandedfac * HEX_HEIGHT)
+
+
+def expandedHexImage(image, factor, topmargin=1.0):
+	"""Add margins around a hex tile image while still keeping the hex centered."""
+	image = asImage(image)
+	horimargin = image.size[0] * (factor-1)/2
+	vertmargin = horimargin * HEX_HEIGHT
+	expandedsize = (round(image.size[0]*factor), round(image.size[1]+vertmargin*(1+topmargin)))
+	expanded = blankFrom(expandedsize)
+	expanded.paste(image, (round(horimargin), round(vertmargin*topmargin)))
+	return expanded
+
+def tesselatedHexImage(image, expandedfac):
+	"""Surround an expanded hex tile with six neighbours."""
+	image = asImage(image)
+	hexwidth, hexheight = hexSize(image, expandedfac)
+	tessed = blankFrom(image)
+	for x, y in ((0,-1), (-0.75,-0.5), (0.75,-0.5), (0,0), (-0.75, 0.5), (0.75, 0.5), (0, 1)):
+		tessed.alpha_composite(image, (round(hexwidth*x), round(hexheight*y)))
+	return tessed
+
+
+def hexMaskCircularOuter(fuzzedscale=2):
+	"""Return a circular mask with fuzzing entirely outside the hex area."""
+	return lambda x, y: max(0, 1-max(0, (math.sqrt((x-0.5)**2+(y-0.5)**2)-0.5)*2/(fuzzedscale-1)))
+
+def clippedModulo(v, divisor, low, high):
+	if v <= low:
+		return v-divisor*(low//divisor)
+	elif v >= high:
+		return v-divisor*(high//divisor)
+	return v % divisor
+
+def polyDistance(x, y, sides, *, rotangle=0.0, minangle=-math.inf, maxangle=math.inf):
+	return math.sqrt(x**2+y**2)*math.cos(clippedModulo((math.atan2(y,x)+rotangle)%(math.pi*2), math.pi/(sides/2), minangle, maxangle)-math.pi/sides)
+
+def hexMaskPolygonalOuter(fuzzedscale=2, sides=6):
+	"""Return a polygonal mask with fuzzing entirely outside the polygon's area."""
+	cornerratio = math.cos(math.pi/6)
+	def mask(x, y):
+		return max(0, 1-max(0, polyDistance(x-0.5, y-0.5, sides)/cornerratio*2-1)/(fuzzedscale-1))
+	return mask
+
+def hexMaskPolygonalBalanced(fuzzedscale=2, sides=6):
+	"""Return a polygonal mask with fuzzing that's split between the polygon's interior and its exterior."""
+	cornerratio = math.cos(math.pi/6)
+	fuzzdistance = (fuzzedscale-1)
+	def mask(x, y):
+		return max(0, 1-max(0, polyDistance(x-0.5, y-0.5, sides, rotangle=math.pi*-2/6, minangle=math.pi*2/3, maxangle=math.pi*4/3)/cornerratio-(0.5-fuzzdistance/2))/fuzzdistance)
+	return mask
+
+def hexMaskVisHex(alpha=0.5):
+	"""Return a hard-edged polygonal mask that sets alpha lower outside the hex area, for visualization purposes."""
+	return lambda x, y: (1 if (abs(x-0.5)*2 / (1 - (abs(y-0.5)))) <= 1 and 0 <= y <= 1 else alpha)
+
+def hexMaskFromImage(expandedfac):
+	raise NotImplementedError()
+
+def maskedHexImage(image, expandedfac, maskfunc=hexMaskVisHex()):
+	"""Apply a transparency mask to an expanded hex tile. The mask function takes X and Y values relative to the bounding rectangle of the hexagon on the tile image, and it returns an opacity."""
+	image = asImage(image)
+	masked = image.copy()
+	hexwidth, hexheight = hexSize(image, expandedfac)
+	centercorner = (round((image.size[0]-hexwidth)/2), image.size[1]-(hexheight*(1+expandedfac)/2))
+	for x in range(masked.size[0]):
+		for y in range(masked.size[1]):
+			coord = (x, y)
+			pix = masked.getpixel(coord)
+			masked.putpixel(coord, (*pix[:3], round(pix[3]*maskfunc((x-centercorner[0])/hexwidth, (y-centercorner[1])/hexheight))))
+	return masked
+
+
+def shadowShearedOrthoImage(image, base_y=0, scale_y=1.0, shear_x=1.0):
+	# Shear an image to be flat on the ground. Doesn't blacken, blur, or make transparent. Takes parameters in pixel-space, not hex-space.
+	image = asImage(image)
+	return image.transform(image.size, PIL.Image.AFFINE,
+			(1, shear_x, -base_y*shear_x,
+			0, 1/scale_y, -((1/scale_y)-1)*base_y)
+		)
+
+def shadowOrthoImage(image, blur=5, *shear_args, **shear_kwargs):
+	# Wraps above, with blackening and blurring. Takes parameters in pixel-space, not hex-space.
+	image = asImage(image)
+	return shadowShearedOrthoImage(PIL.ImageEnhance.Brightness(image).enhance(0.0).filter(PIL.ImageFilter.GaussianBlur(blur)), *shear_args, **shear_kwargs)
+
+def shadowedOrthoImage(image, opacity=0.7, **shadow_kwargs):
+	# Wraps above, with opacity, and composites original image on top of it. Takes parameters in pixel-space, not hex-space.
+	image = asImage(image)
+	r, g, b, a = shadowOrthoImage(image, **shadow_kwargs).split()
+	shadowed = PIL.Image.merge('RGBA', (r, g, b, a.point(lambda a: int(a*opacity))))
+	shadowed.alpha_composite(image, (0, 0))
+	return shadowed
+
+def shadowedOrthoHexImage(image, expandedfac, base=0, opacity=0.7, blur=0.05, length=1.0, shear=1.0):
+	"""Add a sheared shadow to an expanded hex tile with blur radius and base height proportional to the hexagon on it. Base height of 0.0 means the shadow starts at the bottom of the hex; 1.0 means it starts at the top of the hex. Length is a vertical scale factor. Shear is a slope."""
+	image = asImage(image)
+	hexwidth, hexheight = hexSize(image, expandedfac)
+	return shadowedOrthoImage(image, opacity=opacity, blur=hexwidth*blur, base_y=image.size[1]-hexheight*(expandedfac-1)/2-base*hexheight, scale_y=length, shear_x=shear)
+
+
+def dropShadowedHexImage(image, expandedfac, opacity=0.7, blur=0.05, x=0.1, y=0.1):
+	"""Add a drop shadow to an expanded hex tile with blur and offset proportional to the hexagon on it."""
+	image = asImage(image)
+	hexwidth, hexheight = hexSize(image, expandedfac)
+	shadow = shiftedHexImage(PIL.ImageEnhance.Brightness(image).enhance(0.0).filter(PIL.ImageFilter.GaussianBlur(hexwidth*blur)), expandedfac, x, y)
+	r, g, b, a = shadow.split()
+	shadowed = PIL.Image.merge('RGBA', (r, g, b, a.point(lambda a: int(a*opacity))))
+	shadowed.alpha_composite(image, (0, 0))
+	return shadowed
+
+
+def autocroppedHexImage():
+	"""Trim unneeded regions from a hex image. Only trims the top, as bottom and width are used for placement."""
+	raise NotImplementedError()
+
+def shiftedHexImage(image, expandedfac, x=0, y=0):
+	"""Move an expanded hex tile proportionally to the width and height of the hexagon on it."""
+	image = asImage(image)
+	hexwidth, hexheight = hexSize(image, expandedfac)
+	return image.transform(image.size, PIL.Image.AFFINE,
+		(1, 0, -x*hexwidth,
+		0, 1, y*hexheight)
+	)
+
+
+def compositedHexImages(*layers):
+	"""Scale image `layers` to the same width then layer them with their bottoms aligned."""
+	layers = [asImage(image) for image in layers]
+	outwidth = max(layer.size[0] for layer in layers)
+	def scaledToWidth(image):
+		if image.size[0] == outwidth:
+			return image
+		scaleFac = outwidth / image.size[0]
+		return image.transform((outwidth, image.size[1]*scaleFac), PIL.Image.AFFINE,
+			(1/scaleFac, 0, 0,
+			0, 1/scaleFac, 0)
+		)
+	layers = [scaledToWidth(layer) for layer in layers]
+	outheight = max(layer.size[1] for layer in layers)
+	outcanvas = blankFrom((outwidth, outheight))
+	for layer in layers:
+		outcanvas.alpha_composite(layer, (0, outheight-layer.size[1]))
+	return outcanvas
+
+
+mogrifiers = {
+	'expand': lambda scale=1.0, topmargin=1.0: lambda fp: expandedHexImage(fp, scale, topmargin),
+	'tesselate': lambda scale=1.0: lambda fp: tesselatedHexImage(fp, scale),
+	'fuzzCircularDilate': lambda scale=1.0, fuzzedscale=1.5: lambda fp: maskedHexImage(fp, scale, hexMaskCircularOuter(fuzzedscale)),
+	'fuzzPolygonalDilate': lambda scale=1.0, fuzzedscale=1.5, sides=6: lambda fp: maskedHexImage(fp, scale, hexMaskPolygonalOuter(fuzzedscale, sides)),
+	'fuzzPolygonalFeather': lambda scale=1.0, fuzzedscale=1.5, sides=6: lambda fp: maskedHexImage(fp, scale, hexMaskPolygonalBalanced(fuzzedscale, sides)),
+	'shearShadow': lambda scale=1.0, base=0.0, opacity=0.7, blur=0.05, length=1.15, shear=0.6: lambda fp: shadowedOrthoHexImage(fp, expandedfac=scale, base=base, opacity=opacity, blur=blur, length=length, shear=shear),
+	'dropShadow': lambda scale=1.0, opacity=0.5, blur=0.01, x=0.05, y=0.05: lambda fp: dropShadowedHexImage(fp, expandedfac=scale, opacity=opacity, blur=blur, x=x, y=y),
+	'shift': lambda scale=1.0, x=0.0, y=0.0: lambda fp: shiftedHexImage(fp, scale, x, y),
+	'addBackground': lambda *layers: lambda fp: compositedHexImages(*layers, fp)
+}
+
+if __name__ == '__main__':
+	import sys, multiprocessing
+	try:
+		mogstr = sys.argv[1]
+		mogrifier = eval(mogstr, {**mogrifiers})
+		def mog(fp):
+			print(f"Doing {mogstr} on {fp}.")
+			mogrifier(fp).save(fp)
+	except Exception as e:
+		import os
+		print(repr(e))
+		if '__file__' not in globals():
+			__file__ = "TileTransformer.py"
+		print(f"""\n\nUsage: ./{os.path.basename(__file__)} "<command>(<*[[arg]=[value]]>)" [*files]""")
+		print("\nAvailable commands:")
+		for m, f in mogrifiers.items():
+			print(f"\t{m}({', '.join(f'{n}={v}' for n, v in zip(f.__code__.co_varnames, f.__defaults__ or iter(lambda: '*', None)))})")
+		print()
+	else:
+		with multiprocessing.Pool(multiprocessing.cpu_count()) as pool:
+			pool.map(mog, sys.argv[2:])
+

--- a/jsons/TileSets/5Hex.json
+++ b/jsons/TileSets/5Hex.json
@@ -2,6 +2,7 @@
     "useColorAsBaseTerrain": "false",
 		"unexploredTileColor": {"r":1,"g":1,"b":1,"a":1}, //White
 	"fogOfWarColor": {"r":0,"g":0,"b":0,"a":1}, //Black
+	"tileScale": 1.5,
     "ruleVariants": {
 // other	
 		"Forest+Lumber mill": ["Forest+Lumber mill"]


### PR DESCRIPTION
Basically same as #6.

Missing from this PR:
- Some files. Needed because higher `tileScale` means FantasyHex fallbacks will look wrong. Can just copy and paste from FantasyHex, borders example mods, or #6 (for Highlight.png).
- `Images/TileSets/5Hex` needs to be moved to `src/5Hex`.

Most of the other notes on #6 also apply to this.